### PR TITLE
Add allowBlank option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,15 @@ Must use `vmodel.lazy` to bind works properly.
 
 ## Properties
 
-| property  | Required | Type    | Default | Description                                             |
-|-----------|----------|---------|---------|---------------------------------------------------------|
-| precision | **true** | Number  | 2       | How many decimal places                                 |
-| decimal   | false    | String  | "."     | Decimal separator                                       |
-| thousands | false    | String  | ","     | Thousands separator                                     |
-| prefix    | false    | String  | ""      | Currency symbol followed by a Space, like "R$ "         |
-| suffix    | false    | String  | ""      | Percentage for example: " %"                            |
-| masked    | false    | Boolean | false   | If the component output should include the mask or not  |
+| property   | Required | Type    | Default | Description                                             |
+|------------|----------|---------|---------|---------------------------------------------------------|
+| precision  | **true** | Number  | 2       | How many decimal places                                 |
+| decimal    | false    | String  | "."     | Decimal separator                                       |
+| thousands  | false    | String  | ","     | Thousands separator                                     |
+| prefix     | false    | String  | ""      | Currency symbol followed by a Space, like "R$ "         |
+| suffix     | false    | String  | ""      | Percentage for example: " %"                            |
+| masked     | false    | Boolean | false   | If the component output should include the mask or not  |
+| allowBlank | false    | Boolean | false   | If the field can start blank and be cleared out by user |
 
 ### References
 

--- a/src/component.vue
+++ b/src/component.vue
@@ -2,7 +2,7 @@
   <input type="tel"
          :value="formattedValue"
          @change="change"
-         v-money="{precision, decimal, thousands, prefix, suffix}"
+         v-money="{precision, decimal, thousands, prefix, suffix, allowBlank}"
          class="v-money" />
 </template>
 
@@ -42,6 +42,10 @@ export default {
     suffix: {
       type: String,
       default: () => defaults.suffix
+    },
+    allowBlank: {
+      type: Boolean,
+      default: () => defaults.allowBlank
     }
   },
 

--- a/src/directive.js
+++ b/src/directive.js
@@ -1,4 +1,4 @@
-import {format, setCursor, event} from './utils'
+import {format, unformat, setCursor, event} from './utils'
 import assign from './assign'
 import defaults from './options'
 
@@ -13,6 +13,15 @@ export default function (el, binding) {
       // throw new Error("v-money requires 1 input, found " + els.length)
     } else {
       el = els[0]
+    }
+  }
+
+  el.onkeydown = function (e) {
+    var backspacePressed = e.which == 8 || e.which == 46
+    var atEndPosition = (el.value.length - el.selectionEnd) === 0
+    if (opt.allowBlank && backspacePressed && atEndPosition && (unformat(el.value, 0) === 0)) {
+      el.value = ''
+      el.dispatchEvent(event('change')) // v-model.lazy
     }
   }
 

--- a/src/options.js
+++ b/src/options.js
@@ -3,5 +3,6 @@ export default {
   suffix: '',
   thousands: ',',
   decimal: '.',
-  precision: 2
+  precision: 2,
+  allowBlank: false
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,10 @@
 import defaults from './options'
 
 function format (input, opt = defaults) {
+  if (opt.allowBlank && input == '') {
+    return ''
+  }
+
   if (typeof input === 'number') {
     input = input.toFixed(fixed(opt.precision))
   }


### PR DESCRIPTION
Adds a new option that, when set to true, allows v-money fields to be initialized blank or cleared out by the user. The option is false by default, so it should not impact existing v-money fields.

Addresses https://github.com/vuejs-tips/v-money/issues/28