### PR TITLE
pass listeners to input element

### DIFF
--- a/src/component.vue
+++ b/src/component.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <input type="tel"
          :value="formattedValue"
-         @change="change"
+         v-on="listeners"
          v-money="{precision, decimal, thousands, prefix, suffix}"
          class="v-money" />
 </template>
@@ -50,6 +50,15 @@ export default {
   data () {
     return {
       formattedValue: ''
+    }
+  },
+
+  computed: {
+    listeners: {
+      return {
+        ...this.$listeners,
+        change: this.change
+      }
     }
   },
 


### PR DESCRIPTION
**used GitHub editor**

This allows any listeners on the component to be passed down to the input field. This allows all the events like `blur` to work as expected without having to manually specify all of them.